### PR TITLE
prefer central repo, disable releases for asf-snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,15 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
             <id>asf-snapshots</id>
             <url>https://repository.apache.org/content/groups/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <repository>
             <id>asf-staging</id>
@@ -70,10 +77,6 @@
         <repository>
             <id>jakarta-staging</id>
             <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
-        </repository>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
         </repository>
         <repository>
             <id>jboss</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix repository definitions:

1. prefer `central`, not `repository.apache.org`
2. `asf-snapshots` does not have release artifacts

This is to prevent [attempt to download](https://github.com/apache/tomcat-tck/actions/runs/13027096137/job/36338127058#step:4:29955) release artifacts or non-Apache ones from `repository.apache.org`:

```
Downloading from asf-snapshots: https://repository.apache.org/content/groups/snapshots/org/eclipse/jdt/ecj/3.40.0/ecj-3.40.0.jar
```

## How was this patch tested?

Local build:

```
$ mvn -DskipTests clean package
...
[INFO] Reactor Summary for tck 12.0.0-SNAPSHOT:
[INFO] 
[INFO] tck ................................................ SUCCESS [  0.071 s]
[INFO] download ........................................... SUCCESS [ 29.008 s]
[INFO] annotations-tck .................................... SUCCESS [  7.930 s]
[INFO] el-tck ............................................. SUCCESS [  2.357 s]
[INFO] jsp-tck ............................................ SUCCESS [  9.348 s]
[INFO] servlet-tck ........................................ SUCCESS [  1.820 s]
[INFO] websocket-tck ...................................... SUCCESS [  0.786 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

Repo list:

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ tck ---
[INFO] Remote repositories used by project org.apache.tomcat:tck:pom:12.0.0-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * asf-snapshots (https://repository.apache.org/content/groups/snapshots/, default, snapshots)
[INFO]    First introduced on root
[INFO]  * asf-staging (https://repository.apache.org/content/groups/staging/, default, releases+snapshots)
[INFO]    First introduced on root
[INFO]  * jakarta-staging (https://jakarta.oss.sonatype.org/content/repositories/staging/, default, releases+snapshots)
[INFO]    First introduced on root
[INFO]  * jboss (https://repository.jboss.org/nexus/content/repositories/releases/, default, releases+snapshots)
[INFO]    First introduced on root
```
